### PR TITLE
allow symfony/console@~4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
-        "symfony/console": "~2.3|~3.0",
+        "symfony/console": "~2.3|~3.0|~4.0",
         "symfony/process": "~2.3|~3.0"
     },
     "bin": [


### PR DESCRIPTION
I was experiencing the issue described [here](https://github.com/statamic/cli/issues/2), but with 4.0.7 and *without* installing valet, only laravel.

Closes #2.