### PR TITLE
Improve Windows Compatability

### DIFF
--- a/src/Please.php
+++ b/src/Please.php
@@ -32,7 +32,7 @@ class Please
         }
 
         try {
-            $process->setTty(true);
+            $process->setTty(Process::isTtySupported());
         } catch (RuntimeException $e) {
             $this->output->writeln('Warning: '.$e->getMessage());
         }

--- a/statamic
+++ b/statamic
@@ -11,7 +11,15 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
     require __DIR__.'/vendor/autoload.php';
 }
 
-define('STATAMIC_HOME_PATH', $_SERVER['HOME'].'/.statamic');
+if (isset($_SERVER['HOME'])) {
+    $home_path = $_SERVER['HOME'];
+} elseif (isset($_SERVER['HOMEPATH'])) {
+    $home_path = $_SERVER['HOMEPATH'];
+} else {
+    throw new Exception("Could not determine home directory!", 1);
+}
+
+define('STATAMIC_HOME_PATH', $home_path .'/.statamic');
 
 $app = new Symfony\Component\Console\Application('Statamic CLI Tool', '1.0.3');
 $app->add(new Statamic\Cli\NewCommand);


### PR DESCRIPTION
If accepted, this PR should resolve both bugs raised in #11.

Specifically, it implements the following:

- If the `HOME` path cannot be found, it will look for `HOMEPATH` (the Windows equivalent).
- It will only attempt to set TTY mode to `true` when the OS supports it.