### PR TITLE
Bump symfony console and process versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require": {
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
-        "symfony/console": "~2.3|~3.0|~4.0",
-        "symfony/process": "~2.3|~3.0|~4.0"
+        "symfony/console": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/process": "~2.3|~3.0|~4.0|~5.0"
     },
     "bin": [
         "statamic"


### PR DESCRIPTION
References #17. I've bumped both of the allowances to allow for 5.0 of symfony/console and symfony/process.

I've done some cursory tests and it all seems fine. If you have more formal tests that aren't documented in the repo, let me know and I'll run through them for you and attach evidence to this ticket.