### PR TITLE
Bump symfony console and process to version 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     },
     "require": {
         "guzzlehttp/guzzle": "~4.0|~5.0|~6.0",
-        "symfony/console": "~2.3|~3.0|~4.0",
-        "symfony/process": "~2.3|~3.0|~4.0"
+        "symfony/console": "~2.3|~3.0|~4.0|~5.0",
+        "symfony/process": "~2.3|~3.0|~4.0|~5.0"
     },
     "bin": [
         "statamic"

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -55,7 +55,7 @@ class NewCommand extends Command
      *
      * @param  InputInterface  $input
      * @param  OutputInterface  $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -82,6 +82,8 @@ class NewCommand extends Command
             ->createUser();
 
         $this->output->writeln("<info>[✔] Statamic has been installed into the <comment>{$dir}</comment> directory.</info>");
+
+        return 0;
     }
 
     /**

--- a/src/UpdateCommand.php
+++ b/src/UpdateCommand.php
@@ -25,7 +25,7 @@ class UpdateCommand extends Command
      *
      * @param  InputInterface  $input
      * @param  OutputInterface  $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -34,5 +34,7 @@ class UpdateCommand extends Command
         }
 
         (new Please($output))->run('update');
+
+        return 0;
     }
 }

--- a/src/VersionCommand.php
+++ b/src/VersionCommand.php
@@ -25,7 +25,7 @@ class VersionCommand extends Command
      *
      * @param  InputInterface  $input
      * @param  OutputInterface  $output
-     * @return void
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -34,5 +34,7 @@ class VersionCommand extends Command
         }
 
         (new Please($output))->run('version');
+
+        return 0;
     }
 }


### PR DESCRIPTION
Resolves #17.

**What was changed and why**
– Changed the return types of the execute methods to int and return 0 in the new, update, and version commands.
– This is because Symfony no longer allow void to be returned for the execute method.
– It should help avoid issues in version 6 when they enforce a return type.