### PR TITLE
Added Docs Starter Kit and SC Starter Kit

### DIFF
--- a/resources/starter-kits.yaml
+++ b/resources/starter-kits.yaml
@@ -2,7 +2,6 @@ official:
   - statamic/starter-kit-cool-writings
   - statamic/starter-kit-doogie-browser
   - statamic/starter-kit-starters-creek
-third_party: [
+third_party:
   - doublethreedigital/docs-starter-kit
   - doublethreedigital/sc-starter-kit
-]

--- a/resources/starter-kits.yaml
+++ b/resources/starter-kits.yaml
@@ -2,4 +2,7 @@ official:
   - statamic/starter-kit-cool-writings
   - statamic/starter-kit-doogie-browser
   - statamic/starter-kit-starters-creek
-third_party: []
+third_party: [
+  - doublethreedigital/docs-starter-kit
+  - doublethreedigital/sc-starter-kit
+]


### PR DESCRIPTION
I saw there was an empty third party array in the `resources/starter-kits.yaml` file so thought I'd add two of my own starter kits. [One for Simple Commerce](https://github.com/doublethreedigital/sc-starter-kit) and one a [Tailwind CSS inspired Documentation site](https://github.com/doublethreedigital/docs-starter-kit).