### PR TITLE
Misc messaging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Once installed, you should be able to run `statamic {command name}` from within 
 When you install starter kits, the CLI might present you with a warning that the GitHub API limit is reached. [Generate a Personal acces token](https://github.com/settings/tokens/new) and paste it in your terminal with this command so Composer will save it for future use:
 
 ```bash
-composer config --global github-oauth.github.com [your_token_here]
+composer config --global --auth github-oauth.github.com [your_token_here]
 ```
 
 Read more on this in the [Composer Docs](https://getcomposer.org/doc/articles/authentication-for-private-packages.md).

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=7.2.5",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
-        "symfony/console": "^4.0|^5.0",
+        "symfony/console": "^4.0|^5.0|^6.0",
         "symfony/process": "^4.2|^5.0|^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.2.5",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "symfony/console": "^4.0|^5.0",
-        "symfony/process": "^4.2|^5.0"
+        "symfony/process": "^4.2|^5.0|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"

--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -10,20 +10,22 @@ trait RunsCommands
      * Run the given command.
      *
      * @param string $command
+     * @param bool $disableOutput
      * @return Process
      */
-    protected function runCommand($command)
+    protected function runCommand($command, $disableOutput = false)
     {
-        return $this->runCommands([$command]);
+        return $this->runCommands([$command], $disableOutput);
     }
 
     /**
      * Run the given commands.
      *
      * @param array $commands
+     * @param bool $disableOutput
      * @return Process
      */
-    protected function runCommands($commands)
+    protected function runCommands($commands, $disableOutput = false)
     {
         if (! $this->output->isDecorated()) {
             $commands = array_map(function ($value) {
@@ -55,9 +57,11 @@ trait RunsCommands
             }
         }
 
-        $process->run(function ($type, $line) {
-            $this->output->write('    '.$line);
-        });
+        if ($disableOutput) {
+            $process->disableOutput();
+        }
+
+        $process->run();
 
         return $process;
     }

--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -58,10 +58,12 @@ trait RunsCommands
         }
 
         if ($disableOutput) {
-            $process->disableOutput();
+            $process->disableOutput()->run();
+        } else {
+            $process->run(function ($type, $line) {
+                $this->output->write($line);
+            });
         }
-
-        $process->run();
 
         return $process;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -348,9 +348,11 @@ class NewCommand extends Command
         $kitSlug = $details['data']['slug'];
         $marketplaceUrl = "https://statamic.com/starter-kits/{$sellerSlug}/{$kitSlug}";
 
-        $this->output->write(PHP_EOL);
-        $this->output->write('<comment>This is a paid starter kit. If you haven\'t already, you may purchase a license at:</comment>'.PHP_EOL);
-        $this->output->write("<comment>{$marketplaceUrl}</comment>".PHP_EOL);
+        if ($this->input->isInteractive()) {
+            $this->output->write(PHP_EOL);
+            $this->output->write('<comment>This is a paid starter kit. If you haven\'t already, you may purchase a license at:</comment>'.PHP_EOL);
+            $this->output->write("<comment>{$marketplaceUrl}</comment>".PHP_EOL);
+        }
 
         $license = $this->getStarterKitLicense();
 
@@ -403,9 +405,15 @@ class NewCommand extends Command
      */
     protected function confirmSingleSiteLicense()
     {
+        $appendedContinueText = $this->input->isInteractive() ? ' Would you like to continue installation?' : PHP_EOL;
+
         $this->output->write(PHP_EOL);
         $this->output->write('<comment>Once successfully installed, this single-site license will be marked as used</comment>'.PHP_EOL);
-        $this->output->write('<comment>cannot be installed on future Statamic sites. Would you like to continue installation?</comment>');
+        $this->output->write("<comment>and cannot be installed on future Statamic sites!{$appendedContinueText}</comment>");
+
+        if (! $this->input->isInteractive()) {
+            return $this;
+        }
 
         $helper = $this->getHelper('question');
 
@@ -678,6 +686,10 @@ class NewCommand extends Command
     {
         if ($this->starterKitLicense) {
             return $this->starterKitLicense;
+        }
+
+        if (! $this->input->isInteractive()) {
+            throw new RuntimeException('A starter kit license is required, please pass using the `--license` option!');
         }
 
         $helper = $this->getHelper('question');

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -135,7 +135,7 @@ class NewCommand extends Command
         }
 
         $this->output->write(PHP_EOL);
-        $this->output->write("<error>This is an old version of the Statamic CLI Tool, please upgrade to {$this->shouldUpdateCliToVersion}!</error>".PHP_EOL);
+        $this->output->write("<comment>This is an old version of the Statamic CLI Tool, please upgrade to {$this->shouldUpdateCliToVersion}!</comment>".PHP_EOL);
         $this->output->write("<comment>If you have a global composer installation, you may upgrade by running the following command:</comment>".PHP_EOL);
         $this->output->write("<comment>composer global update statamic/cli</comment>".PHP_EOL);
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -83,6 +83,8 @@ class NewCommand extends Command
 
         $this
             ->askForRepo()
+            ->detectRepoVcs()
+            ->detectMissingVcsAuth()
             ->validateStarterKitLicense()
             ->installBaseProject()
             ->installStarterKit()
@@ -257,6 +259,54 @@ class NewCommand extends Command
 
         if ($this->isInvalidStarterKit()) {
             throw new RuntimeException('Please enter a valid composer package name (eg. hasselhoff/kung-fury)!');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Detect starter kit repo vcs, using same precedence logic used in statamic/cms.
+     *
+     * @return $this
+     */
+    protected function detectRepoVcs()
+    {
+        if ($this->local) {
+            return $this;
+        }
+
+        $request = new Client(['http_errors' => false]);
+
+        if ($request->get("https://repo.packagist.org/p2/{$this->starterKit}.json")->getStatusCode() === 200) {
+            return $this;
+        }
+
+        if ($request->get("https://github.com/{$this->starterKit}")->getStatusCode() === 200) {
+            $this->starterKitVcs = 'github';
+        } elseif ($request->get($bitbucketUrl = "https://bitbucket.org/{$this->starterKit}.git")->getStatusCode() === 200) {
+            $this->starterKitVcs = 'bitbucket';
+        } elseif ($request->get($gitlabUrl = "https://gitlab.com/{$this->starterKit}")->getStatusCode() === 200) {
+            $this->starterKitVcs = 'gitlab';
+        }
+
+        return $this;
+    }
+
+    /**
+     * Detect missing starter kit repo vcs auth, and prompt user to properly authenticate.
+     *
+     * @return $this
+     */
+    protected function detectMissingVcsAuth()
+    {
+        if ($this->starterKitVcs === 'github' && $this->hasMissingComposerToken('github-oauth.github.com')) {
+            $this->output->write(PHP_EOL);
+            $this->output->write('<error>Composer could not authenticate with GitHub!</error>'.PHP_EOL);
+            $this->output->write('<comment>Please generate a personal access token at: https://github.com/settings/tokens/new</comment>'.PHP_EOL);
+            $this->output->write('<comment>Then save your token for future use by running the following command:</comment>'.PHP_EOL);
+            $this->output->write('<comment>composer config --global --auth github-oauth.github.com [your-token-here]</comment>'.PHP_EOL);
+
+            return $this->exitInstallation();
         }
 
         return $this;
@@ -638,6 +688,21 @@ class NewCommand extends Command
         }
 
         return $license;
+    }
+
+    /**
+     * Check if user has missing composer token.
+     *
+     * @param string $tokenKey
+     * @return bool
+     */
+    protected function hasMissingComposerToken($tokenKey)
+    {
+        $composer = $this->findComposer();
+
+        return ! $this
+            ->runCommand("{$composer} config --global --auth {$tokenKey}", true)
+            ->isSuccessful();
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -31,6 +31,7 @@ class NewCommand extends Command
     public $absolutePath;
     public $name;
     public $starterKit;
+    public $starterKitVcs;
     public $starterKitLicense;
     public $local;
     public $withConfig;
@@ -224,7 +225,7 @@ class NewCommand extends Command
     }
 
     /**
-     * Ask which starter repo to install.
+     * Ask which starter kit repo to install.
      *
      * @return $this
      */
@@ -707,6 +708,8 @@ class NewCommand extends Command
 
     /**
      * Exit installation.
+     *
+     * @return \stdClass
      */
     protected function exitInstallation()
     {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -112,7 +112,7 @@ class NewCommand extends Command
         try {
             $response = $request->get(self::GITHUB_LATEST_RELEASE_ENDPOINT);
             $latestVersion = json_decode($response->getBody(), true)['tag_name'];
-        } catch (\Exception $exception) {
+        } catch (\Throwable $exception) {
             return $this;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -399,6 +399,11 @@ class NewCommand extends Command
 
         $options = ['--no-interaction', '--clear-site'];
 
+        // Temporary option to inform statamic/cms that user is using new CLI Tool installer.
+        // Since this newer version of the CLI tool will also notify the user of older
+        // CLI tool versions going forward, so we can rip this option out later.
+        $options[] = '--cli-install';
+
         if ($this->local) {
             $options[] = '--local';
         }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -301,7 +301,7 @@ class NewCommand extends Command
         $this->output->write('<comment>This is a paid starter kit. If you haven\'t already, you may purchase a license at:</comment>'.PHP_EOL);
         $this->output->write("<comment>{$marketplaceUrl}</comment>".PHP_EOL);
 
-        $license = $this->getStarterkitLicense();
+        $license = $this->getStarterKitLicense();
 
         try {
             $response = $request->post(self::OUTPOST_ENDPOINT.'validate', ['json' => [
@@ -322,7 +322,7 @@ class NewCommand extends Command
 
         $this->starterKitLicense = $license;
 
-        return $this;
+        return $this->confirmSingleSiteLicense();
     }
 
     /**
@@ -335,6 +335,32 @@ class NewCommand extends Command
         $questionText = 'Starter kit not found on Statamic Marketplace! Install unlisted starter kit? (yes/no) [<comment>yes</comment>]: ';
         $helper = $this->getHelper('question');
         $question = new ConfirmationQuestion($questionText, true);
+
+        $this->output->write(PHP_EOL);
+
+        if (! $helper->ask($this->input, $this->output, $question)) {
+            return $this->exitInstallation();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Confirm single-site license.
+     *
+     * @return $this
+     */
+    protected function confirmSingleSiteLicense()
+    {
+        $this->output->write(PHP_EOL);
+        $this->output->write('<comment>Once successfully installed, this single-site license will be marked as used</comment>'.PHP_EOL);
+        $this->output->write('<comment>cannot be installed on future Statamic sites. Would you like to continue installation?</comment>');
+
+        $helper = $this->getHelper('question');
+
+        $questionText = 'I am aware this is a single-site license (yes/no) [<comment>no</comment>]: ';
+
+        $question = new ConfirmationQuestion($questionText, false);
 
         $this->output->write(PHP_EOL);
 
@@ -597,7 +623,7 @@ class NewCommand extends Command
      *
      * @return string
      */
-    protected function getStarterkitLicense()
+    protected function getStarterKitLicense()
     {
         if ($this->starterKitLicense) {
             return $this->starterKitLicense;


### PR DESCRIPTION
Improve messaging and error output, informing the user as early as possible in the install process...

- [x] Notify when user is running older CLI tool version.
    - This doesn't prevent install, but will show up at the top and bottom of install output.
    ![image](https://user-images.githubusercontent.com/5187394/156255383-d17e8ee1-bd6e-49a3-94f7-490b40604e44.png)
- [x] Handle missing composer auth if starter kit is hosted on github.
    - This does prevent install, but only if a github hosted starter kit is detected.
    ![image](https://user-images.githubusercontent.com/5187394/156088973-f25ee4c8-8dba-4ec9-9e54-7eda7b231355.png)
- [x] Explain single-site starter kit license for paid kids.
    - Ask user to confirm that they understand it's a single-use thing, in order to prevent unnecessary support questions and tickets.
    ![image](https://user-images.githubusercontent.com/5187394/156255542-d1976923-8406-41b5-8c67-b8d511bcaee1.png)
- [x] Improve UX when running non-interactively.
- [x] Update dependencies to remove certain PHP 8.x deprecations in output.
    
**_Do not merge until https://github.com/statamic/cms/pull/5338 is tagged in 3.2!_**

Closes #43
Closes #44