### PR TITLE
Add `—without-dependencies` option for starter kit installations

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -35,6 +35,7 @@ class NewCommand extends Command
     public $starterKitLicense;
     public $local;
     public $withConfig;
+    public $withoutDependencies;
     public $force;
     public $v2;
     public $baseInstallSuccessful;
@@ -56,6 +57,7 @@ class NewCommand extends Command
             ->addOption('license', null, InputOption::VALUE_OPTIONAL, 'Optionally provide explicit starter kit license')
             ->addOption('local', null, InputOption::VALUE_NONE, 'Optionally install from local repo configured in composer config.json')
             ->addOption('with-config', null, InputOption::VALUE_NONE, 'Optionally copy starter-kit.yaml config for local development')
+            ->addOption('without-dependencies', null, InputOption::VALUE_NONE, 'Optionally install starter kit without dependencies')
             ->addOption('v2', null, InputOption::VALUE_NONE, 'Create a legacy Statamic v2 application (not recommended)')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists');
     }
@@ -162,6 +164,7 @@ class NewCommand extends Command
         $this->starterKitLicense = $this->input->getOption('license');
         $this->local = $this->input->getOption('local');
         $this->withConfig = $this->input->getOption('with-config');
+        $this->withoutDependencies = $this->input->getOption('without-dependencies');
 
         $this->force = $this->input->getOption('force');
 
@@ -204,6 +207,10 @@ class NewCommand extends Command
 
         if (! $this->starterKit && $this->withConfig) {
             throw new RuntimeException('Starter kit is required when using `--with-config` option!');
+        }
+
+        if (! $this->starterKit && $this->withoutDependencies) {
+            throw new RuntimeException('Starter kit is required when using `--without-dependencies` option!');
         }
 
         return $this;
@@ -501,6 +508,10 @@ class NewCommand extends Command
         if ($this->starterKitLicense) {
             $options[] = '--license';
             $options[] = $this->starterKitLicense;
+        }
+
+        if ($this->withoutDependencies) {
+            $options[] = '--without-dependencies';
         }
 
         $statusCode = (new Please($this->output))

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -30,6 +30,7 @@ class NewCommand extends Command
     public $relativePath;
     public $absolutePath;
     public $name;
+    public $version;
     public $starterKit;
     public $starterKitVcs;
     public $starterKitLicense;
@@ -159,6 +160,10 @@ class NewCommand extends Command
             : getcwd();
 
         $this->name = pathinfo($this->absolutePath)['basename'];
+
+        $this->version = $this->input->getOption('dev')
+            ? 'dev-master'
+            : '';
 
         $this->starterKit = $this->input->getArgument('starter-kit');
         $this->starterKitLicense = $this->input->getOption('license');
@@ -721,11 +726,9 @@ class NewCommand extends Command
 
         $baseRepo = self::BASE_REPO;
 
-        $version = $this->getVersion();
-
         $directory = $this->pathIsCwd() ? '.' : $this->relativePath;
 
-        return $composer." create-project {$baseRepo} \"{$directory}\" {$version} --remove-vcs --prefer-dist";
+        return $composer." create-project {$baseRepo} \"{$directory}\" {$this->version} --remove-vcs --prefer-dist";
     }
 
     /**
@@ -841,14 +844,5 @@ class NewCommand extends Command
                 return $this;
             }
         };
-    }
-
-    protected function getVersion()
-    {
-        if ($this->input->getOption('dev')) {
-            return 'dev-master';
-        }
-
-        return '';
     }
 }


### PR DESCRIPTION
Add `—without-dependencies` option for starter kit installations.

For example, right now if you install the cool writings starter kit with --dev option for 3.3 beta, you'll get a dependency conflict with the included ssg package. This PR allows you to install without starter kit dependencies to avoid the dependency conflict...

```
statamic new site statamic/starter-kit-cool-writings --dev --without-dependencies
```