### PR TITLE
Allow starter kit installer interactivity

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -448,10 +448,12 @@ class NewCommand extends Command
 
         $options = [
             '--cli-install',
-            '--no-interaction',
             '--clear-site',
         ];
 
+        if (! $this->input->isInteractive()) {
+            $options[] = '--no-interaction';
+        }
 
         if ($this->local) {
             $options[] = '--local';

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -91,6 +91,7 @@ class NewCommand extends Command
             ->makeSuperUser()
             ->notifyIfOldCliVersion()
             ->showSuccessMessage()
+            ->showPostInstallInstructions()
             ->askToSpreadJoy();
 
         return 0;
@@ -617,6 +618,26 @@ class NewCommand extends Command
         $this->output->writeln(PHP_EOL."<info>[✔] Statamic has been successfully installed into the <comment>{$this->relativePath}</comment> directory.</info>");
 
         $this->output->writeln('Build something rad!');
+
+        return $this;
+    }
+
+    /**
+     * Show cached post-install instructions, if provided.
+     *
+     * @return $this
+     */
+    protected function showPostInstallInstructions()
+    {
+        if (! file_exists($instructionsPath = $this->absolutePath.'/storage/statamic/tmp/cli/post-install-instructions.txt')) {
+            return $this;
+        }
+
+        $this->output->write(PHP_EOL);
+
+        foreach (file($instructionsPath) as $line) {
+            $this->output->write('<comment>'.trim($line).'</comment>'.PHP_EOL);
+        }
 
         return $this;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -446,12 +446,12 @@ class NewCommand extends Command
             return $this;
         }
 
-        $options = ['--no-interaction', '--clear-site'];
+        $options = [
+            '--cli-install',
+            '--no-interaction',
+            '--clear-site',
+        ];
 
-        // Temporary option to inform statamic/cms that user is using new CLI Tool installer.
-        // Since this newer version of the CLI tool will also notify the user of older
-        // CLI tool versions going forward, so we can rip this option out later.
-        $options[] = '--cli-install';
 
         if ($this->local) {
             $options[] = '--local';


### PR DESCRIPTION
After releasing https://github.com/statamic/cms/pull/6792, we noticed that `starter-kit:install` is run non-interactively, suppressing any user input prompts in a starter kit's post-install hook. This PR fixes this.

We're also removing the 'temporary' comment on `--cli-install`, because the starter kit installer should never handle the creation of a super user when using this cli installer. It needs to be here anyway, for when installing statamic/statamic without a starter kit.

**Note:** The above-mentioned post-install hook interactivity doesn't work in Windows due to the lack of TTY support in Windows. For these situations, we instead output any cached post-install instructions passed along by statamic/cms...

![CleanShot 2022-10-04 at 17 48 46](https://user-images.githubusercontent.com/5187394/193937459-2a81737b-c819-4cc3-8bc1-ba5bb5e17f81.png)
