### PR TITLE
Statamic 5: Ask about installing first-party addons

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -46,9 +46,9 @@ class NewCommand extends Command
     public $starterKits;
     public $starterKitLicense;
     public $local;
-    public $packages;
     public $withConfig;
     public $withoutDependencies;
+    public $packages;
     public $force;
     public $baseInstallSuccessful;
     public $shouldUpdateCliToVersion = false;
@@ -72,6 +72,7 @@ class NewCommand extends Command
             ->addOption('local', null, InputOption::VALUE_NONE, 'Optionally install from local repo configured in composer config.json')
             ->addOption('with-config', null, InputOption::VALUE_NONE, 'Optionally copy starter-kit.yaml config for local development')
             ->addOption('without-dependencies', null, InputOption::VALUE_NONE, 'Optionally install starter kit without dependencies')
+            ->addOption('package', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Install first-party packages', [])
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists');
     }
 
@@ -240,6 +241,7 @@ class NewCommand extends Command
         $this->withConfig = $this->input->getOption('with-config');
         $this->withoutDependencies = $this->input->getOption('without-dependencies');
 
+        $this->packages = $this->input->getOption('package');
         $this->force = $this->input->getOption('force');
 
         return $this;
@@ -565,7 +567,7 @@ class NewCommand extends Command
 
     protected function askToInstallPackages()
     {
-        if (! $this->input->isInteractive()) {
+        if ($this->packages || ! $this->input->isInteractive()) {
             return $this;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -48,7 +48,7 @@ class NewCommand extends Command
     public $local;
     public $withConfig;
     public $withoutDependencies;
-    public $packages;
+    public $addons;
     public $force;
     public $baseInstallSuccessful;
     public $shouldUpdateCliToVersion = false;
@@ -72,7 +72,7 @@ class NewCommand extends Command
             ->addOption('local', null, InputOption::VALUE_NONE, 'Optionally install from local repo configured in composer config.json')
             ->addOption('with-config', null, InputOption::VALUE_NONE, 'Optionally copy starter-kit.yaml config for local development')
             ->addOption('without-dependencies', null, InputOption::VALUE_NONE, 'Optionally install starter kit without dependencies')
-            ->addOption('package', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Install first-party packages', [])
+            ->addOption('addon', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Install first-party addons?', [])
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists');
     }
 
@@ -116,14 +116,14 @@ class NewCommand extends Command
             ->validateArguments()
             ->askForRepo()
             ->validateStarterKitLicense()
-            ->askToInstallPackages()
+            ->askToInstallAddons()
             ->askToMakeSuperUser()
             ->askToSpreadJoy()
             ->readySetGo()
             ->installBaseProject()
             ->installStarterKit()
             ->makeSuperUser()
-            ->installPackages()
+            ->installAddons()
             ->notifyIfOldCliVersion()
             ->showSuccessMessage()
             ->showPostInstallInstructions();
@@ -241,7 +241,7 @@ class NewCommand extends Command
         $this->withConfig = $this->input->getOption('with-config');
         $this->withoutDependencies = $this->input->getOption('without-dependencies');
 
-        $this->packages = $this->input->getOption('package');
+        $this->addons = $this->input->getOption('addon');
         $this->force = $this->input->getOption('force');
 
         return $this;
@@ -565,38 +565,38 @@ class NewCommand extends Command
         return $this;
     }
 
-    protected function askToInstallPackages()
+    protected function askToInstallAddons()
     {
-        if ($this->packages || ! $this->input->isInteractive()) {
+        if ($this->addons || ! $this->input->isInteractive()) {
             return $this;
         }
 
-        $this->packages = multiselect('Would you like to install any first-party packages?', [
+        $this->addons = multiselect('Would you like to install any first-party addons?', [
             'collaboration' => 'Collaboration',
             'eloquent-driver' => 'Eloquent Driver',
             'ssg' => 'Static Site Generator',
         ]);
 
-        if (count($this->packages) > 0) {
+        if (count($this->addons) > 0) {
             $this->output->write("  Great. We'll get these installed right after we setup your Statamic site.".PHP_EOL.PHP_EOL);
         }
 
         return $this;
     }
 
-    protected function installPackages()
+    protected function installAddons()
     {
-        if (! $this->packages) {
+        if (! $this->addons) {
             return $this;
         }
 
-        collect($this->packages)->each(function (string $package) {
+        collect($this->addons)->each(function (string $addon) {
             $statusCode = (new Please($this->output))
                 ->cwd($this->absolutePath)
-                ->run("install:{$package}");
+                ->run("install:{$addon}");
 
             if ($statusCode !== 0) {
-                throw new RuntimeException("There was a problem installing the [{$package}] package!");
+                throw new RuntimeException("There was a problem installing the [{$addon}] addon!");
             }
         });
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -3,14 +3,10 @@
 namespace Statamic\Cli;
 
 use GuzzleHttp\Client;
-use function Laravel\Prompts\confirm;
 use Laravel\Prompts\ConfirmPrompt;
 use Laravel\Prompts\Prompt;
-use function Laravel\Prompts\select;
 use Laravel\Prompts\SelectPrompt;
-use function Laravel\Prompts\suggest;
 use Laravel\Prompts\SuggestPrompt;
-use function Laravel\Prompts\text;
 use Laravel\Prompts\TextPrompt;
 use RuntimeException;
 use Statamic\Cli\Theme\ConfirmPromptRenderer;
@@ -25,9 +21,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\suggest;
+use function Laravel\Prompts\text;
+
 class NewCommand extends Command
 {
-    use Concerns\RunsCommands, Concerns\ConfiguresPrompts;
+    use Concerns\ConfiguresPrompts, Concerns\RunsCommands;
 
     const BASE_REPO = 'statamic/statamic';
     const OUTPOST_ENDPOINT = 'https://outpost.statamic.com/v3/starter-kits/';


### PR DESCRIPTION
This pull request adds a question to the `statamic new` command, giving developers the option to install first-addons right after setting up their site. 

![CleanShot 2024-05-02 at 11 55 38](https://github.com/statamic/cli/assets/19637309/0a35de93-d5e4-4770-a85d-d78551f8dad6)

Under the hood, this will use the new `install:*` commands introduced in v5. 

Developers can also pass addons as options to the command, for example:

```sh
statamic new blahblahblah --addon=eloquent-driver --addon=ssg
```