### PR TITLE
Ask yes/no question before showing first-party addons multiselect

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -583,11 +583,15 @@ class NewCommand extends Command
             return $this;
         }
 
-        $this->addons = multiselect('Which first-party addons do you want to install?', [
-            'collaboration' => 'Collaboration',
-            'eloquent-driver' => 'Eloquent Driver',
-            'ssg' => 'Static Site Generator',
-        ]);
+        $this->addons = multiselect(
+            label: 'Which first-party addons do you want to install?',
+            options: [
+                'collaboration' => 'Collaboration',
+                'eloquent-driver' => 'Eloquent Driver',
+                'ssg' => 'Static Site Generator',
+            ],
+            hint: 'Use the space bar to select options.'
+        );
 
         if (count($this->addons) > 0) {
             $this->output->write("  Great. We'll get these installed right after we setup your Statamic site.".PHP_EOL.PHP_EOL);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -571,7 +571,19 @@ class NewCommand extends Command
             return $this;
         }
 
-        $this->addons = multiselect('Would you like to install any first-party addons?', [
+        $choice = select(
+            label: 'Would you like to install any first-party addons?',
+            options: [
+                $withoutAddonsOption = "No, I'm good for now.",
+                "Yes, let me pick.",
+            ],
+        );
+
+        if ($choice === $withoutAddonsOption) {
+            return $this;
+        }
+
+        $this->addons = multiselect('Which first-party addons do you want to install?', [
             'collaboration' => 'Collaboration',
             'eloquent-driver' => 'Eloquent Driver',
             'ssg' => 'Static Site Generator',


### PR DESCRIPTION
This pull request adds a "yes/no" prompt to the CLI before showing the first-party addons multiselect introduced in #71.

![CleanShot 2024-05-10 at 18 31 13](https://github.com/statamic/cli/assets/19637309/e7af946f-370e-42d3-b7ee-fd0dc18c659e)