### PR TITLE
Git support

### DIFF
--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -9,27 +9,33 @@ trait RunsCommands
     /**
      * Run the given command.
      *
-     * @param  string  $command
-     * @param  bool  $disableOutput
+     * @param string $command
+     * @param string|null $workingPath
+     * @param bool $disableOutput
      * @return Process
      */
-    protected function runCommand($command, $disableOutput = false)
+    protected function runCommand(string $command, string $workingPath = null, bool $disableOutput = false)
     {
-        return $this->runCommands([$command], $disableOutput);
+        return $this->runCommands([$command], $workingPath, $disableOutput);
     }
 
     /**
      * Run the given commands.
      *
-     * @param  array  $commands
-     * @param  bool  $disableOutput
+     * @param array $commands
+     * @param string|null $workingPath
+     * @param bool $disableOutput
      * @return Process
      */
-    protected function runCommands($commands, $disableOutput = false)
+    protected function runCommands(array $commands, string $workingPath = null, bool $disableOutput = false)
     {
         if (! $this->output->isDecorated()) {
             $commands = array_map(function ($value) {
-                if (substr($value, 0, 5) === 'chmod') {
+                if (str_starts_with($value, 'chmod')) {
+                    return $value;
+                }
+
+                if (str_starts_with($value, 'git')) {
                     return $value;
                 }
 
@@ -39,7 +45,11 @@ trait RunsCommands
 
         if ($this->input->getOption('quiet')) {
             $commands = array_map(function ($value) {
-                if (substr($value, 0, 5) === 'chmod') {
+                if (str_starts_with($value, 'chmod')) {
+                    return $value;
+                }
+
+                if (str_starts_with($value, 'git')) {
                     return $value;
                 }
 
@@ -47,7 +57,7 @@ trait RunsCommands
             }, $commands);
         }
 
-        $process = Process::fromShellCommandline(implode(' && ', $commands), null, null, null, null);
+        $process = Process::fromShellCommandline(implode(' && ', $commands), $workingPath);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             try {

--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -31,11 +31,7 @@ trait RunsCommands
     {
         if (! $this->output->isDecorated()) {
             $commands = array_map(function ($value) {
-                if (str_starts_with($value, 'chmod')) {
-                    return $value;
-                }
-
-                if (str_starts_with($value, 'git')) {
+                if (substr($value, 0, 5) === 'chmod') {
                     return $value;
                 }
 
@@ -45,11 +41,7 @@ trait RunsCommands
 
         if ($this->input->getOption('quiet')) {
             $commands = array_map(function ($value) {
-                if (str_starts_with($value, 'chmod')) {
-                    return $value;
-                }
-
-                if (str_starts_with($value, 'git')) {
+                if (substr($value, 0, 5) === 'chmod') {
                     return $value;
                 }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -776,7 +776,7 @@ class NewCommand extends Command
      * @param  string  $directory
      * @return void
      */
-    protected function commitChanges(string $message, string $directory)
+    protected function commitChanges(string $message)
     {
         if (! $this->initializeGitRepository || ! $this->isGitInstalled()) {
             return;
@@ -787,7 +787,7 @@ class NewCommand extends Command
             "git commit -q -m \"$message\"",
         ];
 
-        $this->runCommands($commands, workingPath: $directory);
+        $this->runCommands($commands, workingPath: $this->absolutePath);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -764,9 +764,30 @@ class NewCommand extends Command
             "git branch -M {$branch}",
         ];
 
-        $this->runCommands($commands, $this->absolutePath);
+        $this->runCommands($commands, workingPath: $this->absolutePath);
 
         return $this;
+    }
+
+    /**
+     * Commit any changes in the current working directory.
+     *
+     * @param  string  $message
+     * @param  string  $directory
+     * @return void
+     */
+    protected function commitChanges(string $message, string $directory)
+    {
+        if (! $this->initializeGitRepository || ! $this->isGitInstalled()) {
+            return;
+        }
+
+        $commands = [
+            'git add .',
+            "git commit -q -m \"$message\"",
+        ];
+
+        $this->runCommands($commands, workingPath: $directory);
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -60,9 +60,9 @@ class NewCommand extends Command
     public $makeUser = false;
     public $initializeGitRepository = false;
     public $shouldPushToGithub = false;
-    public $spreadJoy = false;
     public $githubRepository;
     public $repositoryVisibility;
+    public $spreadJoy = false;
 
     /**
      * Configure the command options.

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -808,6 +808,7 @@ class NewCommand extends Command
         if (
             ! $this->initializeGitRepository
             || ! $this->isGitInstalled()
+            || ! $this->isGhInstalled()
             || ! $this->input->isInteractive()
         ) {
             return $this;
@@ -853,14 +854,6 @@ class NewCommand extends Command
             return $this;
         }
 
-        $process = new Process(['gh', 'auth', 'status']);
-        $process->run();
-
-        if (! $process->isSuccessful()) {
-            $this->output->writeln('  <bg=yellow;fg=black> WARN </> Make sure the "gh" CLI tool is installed and that you\'re authenticated to GitHub. Skipping...'.PHP_EOL);
-
-            return $this;
-        }
 
         $commands = [
             "gh repo create {$this->githubRepository} --source=. --push --{$this->repositoryVisibility}",
@@ -869,6 +862,20 @@ class NewCommand extends Command
         $this->runCommands($commands, $this->absolutePath, disableOutput: true);
 
         return $this;
+    }
+
+    /**
+     * Check if GitHub's GH CLI tool is installed.
+     *
+     * @return bool
+     */
+    protected function isGhInstalled(): bool
+    {
+        $process = new Process(['gh', 'auth', 'status']);
+
+        $process->run();
+
+        return $process->isSuccessful();
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -37,12 +37,8 @@ class NewCommand extends Command
     const GITHUB_LATEST_RELEASE_ENDPOINT = 'https://api.github.com/repos/statamic/cli/releases/latest';
     const STATAMIC_API_URL = 'https://statamic.com/api/v1/';
 
-    /** @var InputInterface */
     public $input;
-
-    /** @var OutputInterface */
     public $output;
-
     public $relativePath;
     public $absolutePath;
     public $name;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -766,27 +766,6 @@ class NewCommand extends Command
     }
 
     /**
-     * Commit any changes in the current working directory.
-     *
-     * @param  string  $message
-     * @param  string  $directory
-     * @return void
-     */
-    protected function commitChanges(string $message)
-    {
-        if (! $this->initializeGitRepository || ! $this->isGitInstalled()) {
-            return;
-        }
-
-        $commands = [
-            'git add .',
-            "git commit -q -m \"$message\"",
-        ];
-
-        $this->runCommands($commands, workingPath: $this->absolutePath);
-    }
-
-    /**
      * Check if Git is installed.
      *
      * @return bool

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -259,8 +259,8 @@ class NewCommand extends Command
         $this->withoutDependencies = $this->input->getOption('without-dependencies');
         $this->addons = $this->input->getOption('addon');
         $this->force = $this->input->getOption('force');
-        $this->initializeGitRepository = $this->input->getOption('git') || $this->input->getOption('github');
-        $this->shouldPushToGithub = $this->input->getOption('github');
+        $this->initializeGitRepository = $this->input->getOption('git') !== false || $this->input->getOption('github') !== false;
+        $this->shouldPushToGithub = $this->input->getOption('github') !== false;
         $this->githubRepository = $this->input->getOption('repo');
         $this->repositoryVisibility = $this->input->getOption('github');
 
@@ -819,25 +819,25 @@ class NewCommand extends Command
                 label: 'Would you like to create a new repository on GitHub?',
                 default: false
             );
-        }
 
-        if ($this->shouldPushToGithub && ! $this->githubRepository) {
-            $this->githubRepository = text(
-                label: 'What should be your full repository name?',
-                default: $this->name,
-                required: true,
-            );
-        }
+            if ($this->shouldPushToGithub && ! $this->githubRepository) {
+                $this->githubRepository = text(
+                    label: 'What should be your full repository name?',
+                    default: $this->name,
+                    required: true,
+                );
+            }
 
-        if ($this->shouldPushToGithub && ! $this->repositoryVisibility) {
-            $this->repositoryVisibility = select(
-                label: 'Should the repository be public or private?',
-                options: [
-                    'public' => 'Public',
-                    'private' => 'Private',
-                ],
-                default: 'private',
-            );
+            if ($this->shouldPushToGithub && ! $this->repositoryVisibility) {
+                $this->repositoryVisibility = select(
+                    label: 'Should the repository be public or private?',
+                    options: [
+                        'public' => 'Public',
+                        'private' => 'Private',
+                    ],
+                    default: 'private',
+                );
+            }
         }
 
         return $this;

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -80,6 +80,8 @@ class NewCommand extends Command
             ->addOption('addon', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Install first-party addons?', [])
             ->addOption('git', null, InputOption::VALUE_NONE, 'Initialize a Git repository')
             ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'The branch that should be created for a new repository')
+            ->addOption('github', null, InputOption::VALUE_OPTIONAL, 'Create a new repository on GitHub', false)
+            ->addOption('organization', null, InputOption::VALUE_REQUIRED, 'The GitHub organization to create the new repository for')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists');
     }
 
@@ -133,6 +135,7 @@ class NewCommand extends Command
             ->makeSuperUser()
             ->installAddons()
             ->initializeGitRepository()
+            ->pushToGithub()
             ->notifyIfOldCliVersion()
             ->showSuccessMessage()
             ->showPostInstallInstructions();
@@ -716,7 +719,12 @@ class NewCommand extends Command
      */
     protected function askToInitializeGitRepository()
     {
-        if ($this->input->getOption('git') || ! $this->input->isInteractive() || ! $this->gitIsInstalled()) {
+        if (
+            ! $this->gitIsInstalled()
+            || ! $this->input->isInteractive()
+            || $this->input->getOption('git') !== false
+            || $this->input->getOption('github') !== false
+        ) {
             return $this;
         }
 
@@ -735,7 +743,10 @@ class NewCommand extends Command
      */
     protected function initializeGitRepository()
     {
-        if (! $this->input->getOption('git') || ! $this->gitIsInstalled()) {
+        if (
+            ! $this->gitIsInstalled()
+            || ($this->input->getOption('git') === false && $this->input->getOption('github') === false)
+        ) {
             return $this;
         }
 
@@ -753,6 +764,11 @@ class NewCommand extends Command
         return $this;
     }
 
+    /**
+     * Check if Git is installed.
+     *
+     * @return bool
+     */
     protected function gitIsInstalled(): bool
     {
         $process = new Process(['git', '--version']);
@@ -767,7 +783,7 @@ class NewCommand extends Command
      *
      * @return string
      */
-    protected function defaultBranch()
+    protected function defaultBranch(): string
     {
         $process = new Process(['git', 'config', '--global', 'init.defaultBranch']);
         $process->run();
@@ -775,6 +791,38 @@ class NewCommand extends Command
         $output = trim($process->getOutput());
 
         return $process->isSuccessful() && $output ? $output : 'main';
+    }
+
+    /**
+     * Create a GitHub repository and push the git log to it.
+     *
+     * @return $this
+     */
+    protected function pushToGithub()
+    {
+        if ($this->input->getOption('github') === false) {
+            return $this;
+        }
+
+        $process = new Process(['gh', 'auth', 'status']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $this->output->writeln('  <bg=yellow;fg=black> WARN </> Make sure the "gh" CLI tool is installed and that you\'re authenticated to GitHub. Skipping...'.PHP_EOL);
+
+            return $this;
+        }
+
+        $name = $this->input->getOption('organization') ? $this->input->getOption('organization')."/$this->name" : $this->name;
+        $flags = $this->input->getOption('github') ?: '--private';
+
+        $commands = [
+            "gh repo create {$name} --source=. --push {$flags}",
+        ];
+
+        $this->runCommands($commands, $this->absolutePath, disableOutput: true);
+
+        return $this;
     }
 
     /**

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -65,7 +65,6 @@ class NewCommand extends Command
     public $githubRepository;
     public $repositoryVisibility;
     public $pro = true;
-    public $spreadJoy = false;
 
     /**
      * Configure the command options.

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -854,9 +854,11 @@ class NewCommand extends Command
             return $this;
         }
 
+        $name = $this->githubRepository ?? $this->name;
+        $visibility = $this->repositoryVisibility ?? 'private';
 
         $commands = [
-            "gh repo create {$this->githubRepository} --source=. --push --{$this->repositoryVisibility}",
+            "gh repo create {$name} --source=. --push --{$visibility}",
         ];
 
         $this->runCommands($commands, $this->absolutePath, disableOutput: true);


### PR DESCRIPTION
This pull request adds Git support to the `statamic new` command. It'll allow users to setup up a Git repository for their new site.

Additionally, if you have [GitHub's `gh` CLI tool](https://cli.github.com/) installed, it'll let you create repositories on GitHub.

Closes #69.

## Usage

https://github.com/user-attachments/assets/f6a9beb2-5f34-423a-9a09-e507ff322b7b

If you'd prefer to provide flags to the command, you can do that too:

```shell
# Initializes a Git repo
statamic new client-site.com --git

# Initializes a Git repo, pushes it to a private GitHub repo
statamic new client-site.com --github

# Initializes a Git repo, pushes it to a public GitHub repo called "myblog.me"
statamic new client-site.com --github=public --repo=myblog.me
```