### PR TITLE
Laravel Pint

### DIFF
--- a/.github/workflows/pint-fix.yml
+++ b/.github/workflows/pint-fix.yml
@@ -1,0 +1,31 @@
+name: Fix PHP code style issues
+
+on:
+  push:
+    paths:
+      - '**.php'
+
+permissions:
+  contents: write
+
+jobs:
+  fix-php-code-styling:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'statamic'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.PINT }}
+
+      - name: Fix PHP code style issues
+        uses: aglipanci/laravel-pint-action@v2
+        with:
+          pintVersion: 1.16.0
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Fix styling

--- a/.github/workflows/pint-link.yml
+++ b/.github/workflows/pint-link.yml
@@ -1,0 +1,21 @@
+name: Lint PHP code style issues
+
+on:
+  pull_request:
+    paths:
+      - '**.php'
+
+jobs:
+  lint-php-code-styling:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check PHP code style issues
+        uses: aglipanci/laravel-pint-action@v2
+        with:
+          testMode: true
+          verboseMode: true
+          pintVersion: 1.16.0


### PR DESCRIPTION
I've realised that I don't have Laravel Pint setup in PHPStorm, so my recent changes wouldn't have been tidied up.

I know we only touch this project every so often, but I thought it might be a good idea to add the GitHub Actions we use on `cms` for Pint'ing code.