### PR TITLE
Add Github create repo organization hint

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -883,6 +883,7 @@ class NewCommand extends Command
                 $this->githubRepository = text(
                     label: 'What should be your full repository name?',
                     default: $this->name,
+                    hint: "Use `organization/$this->name` to create an organization repo.",
                     required: true,
                 );
             }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -883,7 +883,7 @@ class NewCommand extends Command
                 $this->githubRepository = text(
                     label: 'What should be your full repository name?',
                     default: $this->name,
-                    hint: "Use `organization/$this->name` to create an organization repo.",
+                    hint: "Use `yourorg/$this->name` to create a repo in your organization.",
                     required: true,
                 );
             }


### PR DESCRIPTION
By default it will push to your personal authenticated Github account. If you're part of an organization you can prepend that to the repo name to create a repo there. This PR adds a hint to explain that.