### PR TITLE
[5.x] Fix timeout on slow Composer commands

### DIFF
--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -57,7 +57,7 @@ trait RunsCommands
             }, $commands);
         }
 
-        $process = Process::fromShellCommandline(implode(' && ', $commands), $workingPath);
+        $process = Process::fromShellCommandline(implode(' && ', $commands), $workingPath, timeout: null);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             try {


### PR DESCRIPTION
This pull request fixes an issue where the `composer create-project` command to install the `statamic/statamic` base project would timeout if it took longer than 60 seconds.

Someone ran into this on Discord yesterday and I just ran into it when helping a family member install Statamic on Windows.