### PR TITLE
Add email and password options

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -353,6 +353,7 @@ class NewCommand extends Command
                 $blankSiteOption = 'No, start with a blank site.',
                 'Yes, let me pick a Starter Kit.',
             ],
+            default: $blankSiteOption
         );
 
         if ($choice === $blankSiteOption) {

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -740,7 +740,7 @@ class NewCommand extends Command
         }
 
         // Since Windows cannot TTY, we'll capture their input here and make a user.
-        if ($this->input->isInteractive() && PHP_OS_FAMILY === 'Windows') {
+        if ($this->input->isInteractive() && ! $email && PHP_OS_FAMILY === 'Windows') {
             return $this->makeSuperUserInWindows();
         }
 


### PR DESCRIPTION
This adds `--email` and `--password` options.

Using the `--email` option will bypass the "Create a super user?" prompt as well as the email/password/etc prompts.

If you use `--email` without `--password`, the user's password will be literally `password`. 

This also removes the "name" prompt from the fallback windows user logic. It's nice to get rid of the hacky tinker user-updating code. Name is not really necessary. They can always update it later.

### Examples

```
statamic new myapp --email=me@site.com --password=test
```
Password will be `test`.

---

```
statamic new myapp --email=me@site.com
```
Password will be `password`.

---

```
statamic new myapp --password=test
```
Since you don't use the `email` option, the `password` option will be ignored, and you will get all the prompts.

---

```
statamic new myapp
```
You will get all the prompts as you always did.