### PR TITLE
Add default to the starter kit prompt

### DIFF
--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -351,6 +351,7 @@ class NewCommand extends Command
                 $blankSiteOption = 'No, start with a blank site.',
                 'Yes, let me pick a Starter Kit.',
             ],
+            default: $blankSiteOption
         );
 
         if ($choice === $blankSiteOption) {


### PR DESCRIPTION
On the "Would you like to install a starter kit?" question when using Windows, hitting enter didn't work because we weren't passing a default value.
