### PR TITLE
Add `illuminate/support` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "laravel/prompts": "^0.1.3|^0.2.0|^0.3.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "symfony/console": "^4.0|^5.0|^6.0|^7.0",
         "symfony/process": "^4.2|^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
This pull request adds `illuminate/support` as an explicit dependency for the Statamic CLI. 

By requiring it explicitly, it ensures that the `collect()` function is available, which we use in our "do you want to setup a database" prompt.

When we tested the database prompt before release, we probably had other global Composer dependencies installed which required `illuminate/support`, making `collect()` available. However, if you don't have any other global dependencies installed, you might have seen a `Call to undefined function Statamic\Cli\Concerns\collect()` error.

Fixes #96.