### PR TITLE
Run migrations using `php artisan`

### DIFF
--- a/src/Artisan.php
+++ b/src/Artisan.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Statamic\Cli;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+class Artisan
+{
+    protected $output;
+    protected $cwd;
+
+    /**
+     * Instantiate Laravel `artisan` command wrapper.
+     */
+    public function __construct(OutputInterface $output)
+    {
+        $this->output = $output;
+    }
+
+    /**
+     * Get or set current working directory.
+     *
+     * @param  mixed  $cwd
+     * @return mixed
+     */
+    public function cwd($cwd = null)
+    {
+        if (func_num_args() === 0) {
+            return $this->cwd ?? getcwd();
+        }
+
+        $this->cwd = $cwd;
+
+        return $this;
+    }
+
+    /**
+     * Run artisan command.
+     *
+     * @param  mixed  $commandParts
+     * @return int
+     */
+    public function run(...$commandParts)
+    {
+        if (! is_file($this->cwd().'/artisan')) {
+            throw new \RuntimeException('This does not appear to be a Laravel project.');
+        }
+
+        $process = (new Process(array_merge([PHP_BINARY, 'artisan'], $commandParts)))
+            ->setTimeout(null);
+
+        if ($this->cwd) {
+            $process->setWorkingDirectory($this->cwd);
+        }
+
+        try {
+            $process->setTty(true);
+        } catch (RuntimeException $e) {
+            // TTY not supported. Move along.
+        }
+
+        $process->run(function ($type, $line) {
+            $this->output->write($line);
+        });
+
+        return $process->getExitCode();
+    }
+}

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -610,7 +610,7 @@ class NewCommand extends Command
             $command[] = '--no-interaction';
         }
 
-        $migrate = (new Please($this->output))
+        $migrate = (new Artisan($this->output))
             ->cwd($this->absolutePath)
             ->run(...$command);
 


### PR DESCRIPTION
This pull request fixes an error when creating new sites w/ a database:

```
 Which database will your application use? ───────────────────┐
 │ MySQL                                                        │
 └──────────────────────────────────────────────────────────────┘


                                               
  Not enough arguments (missing: "timezone").  
                                               

   There was a problem connecting to the database. 

  Once the install process is complete, please run php please install:eloquent-driver to finish setting up the database.
```

This was happening because...

1. We were running `php please migrate`.
2. The `statamic:migrate-dates-to-utc` command becomes `migrate-dates-to-utc` in Please.
3. Symfony's console uses abbreviation matching, meaning `migrate` is a valid abbreviation/prefix of `migrate-dates-to-utc`.
4. It meant that `php please migrate` would end up matching `migrate-dates-to-utc`, rather than falling back to Laravel's `migrate` command, like it did < v6.
5. The command [requires a `timezone` argument](https://github.com/statamic/cms/blob/0152f65e75ff25f4cae9e384d9b09c40e9d8746f/src/Console/Commands/MigrateDatesToUtc.php#L46), hence the error.

This PR fixes it by explicitly using `php artisan` to run the migration command, rather than rely on the fallback behaviour of `php please`.

Fixes #101