### PR TITLE
Support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
         "laravel/prompts": "^0.1.3|^0.2.0|^0.3.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "symfony/console": "^4.0|^5.0|^6.0|^7.0",
         "symfony/process": "^4.2|^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
The Statamic CLI is preventing my `composer global` from updating Laravel.

Considering `illuminate/support` is only there for `collect()` this shouldn't give any problems.