### PR TITLE
Swap `illuminate/support` for `illuminate/collections`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^6.5.5|^7.0.1",
+        "illuminate/collections": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.3|^0.2.0|^0.3.0",
-        "illuminate/support": "^10.0|^11.0|^12.0",
         "symfony/console": "^4.0|^5.0|^6.0|^7.0",
         "symfony/process": "^4.2|^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
Since `illuminate/support` has only been included for `collect()` (#97), narrow it down to `illuminate/collections` to shave down a few transitive depencies