### PR TITLE
Collapse install output with task()

### DIFF
--- a/src/Concerns/RunsCommands.php
+++ b/src/Concerns/RunsCommands.php
@@ -2,7 +2,11 @@
 
 namespace Statamic\Cli\Concerns;
 
+use Laravel\Prompts\Support\Logger;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+
+use function Laravel\Prompts\task;
 
 trait RunsCommands
 {
@@ -11,9 +15,9 @@ trait RunsCommands
      *
      * @return Process
      */
-    protected function runCommand(string $command, ?string $workingPath = null, bool $disableOutput = false)
+    protected function runCommand(string $command, ?string $workingPath = null, bool $disableOutput = false, ?string $taskLabel = null)
     {
-        return $this->runCommands([$command], $workingPath, $disableOutput);
+        return $this->runCommands([$command], $workingPath, $disableOutput, $taskLabel);
     }
 
     /**
@@ -21,7 +25,7 @@ trait RunsCommands
      *
      * @return Process
      */
-    protected function runCommands(array $commands, ?string $workingPath = null, bool $disableOutput = false)
+    protected function runCommands(array $commands, ?string $workingPath = null, bool $disableOutput = false, ?string $taskLabel = null)
     {
         if (! $this->output->isDecorated()) {
             $commands = array_map(function ($value) {
@@ -53,6 +57,10 @@ trait RunsCommands
 
         $process = Process::fromShellCommandline(implode(' && ', $commands), $workingPath, timeout: null);
 
+        if ($taskLabel && ! $disableOutput && $this->shouldRunAsTask()) {
+            return $this->runProcessAsTask($process, $taskLabel);
+        }
+
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
             try {
                 if ($this->input->hasOption('no-interaction') && $this->input->getOption('no-interaction')) {
@@ -72,6 +80,39 @@ trait RunsCommands
                 $this->output->write('    '.$line);
             });
         }
+
+        return $process;
+    }
+
+    /**
+     * Determine if the process should be rendered as a collapsible Prompts task.
+     */
+    private function shouldRunAsTask(): bool
+    {
+        return $this->output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
+            && $this->output->isDecorated()
+            && function_exists('Laravel\Prompts\task')
+            && function_exists('pcntl_fork');
+    }
+
+    /**
+     * Run the given process within a Laravel Prompts task, streaming its output into the task's log.
+     */
+    private function runProcessAsTask(Process $process, string $taskLabel): Process
+    {
+        task(
+            label: $taskLabel,
+            keepSummary: true,
+            callback: function (Logger $logger) use ($process) {
+                $process->run(function ($type, $line) use ($logger) {
+                    $logger->line($line);
+                });
+
+                if (! $process->isSuccessful()) {
+                    $logger->error(trim($process->getErrorOutput()));
+                }
+            },
+        );
 
         return $process;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -507,7 +507,7 @@ class NewCommand extends Command
             $commands[] = "chmod 755 \"$this->absolutePath/please\"";
         }
 
-        $this->runCommands($commands);
+        $this->runCommands($commands, taskLabel: 'Installing Statamic');
 
         if (! $this->wasBaseInstallSuccessful()) {
             throw new RuntimeException('There was a problem installing Statamic!');
@@ -835,7 +835,7 @@ class NewCommand extends Command
             "git branch -M {$branch}",
         ];
 
-        $this->runCommands($commands, workingPath: $this->absolutePath);
+        $this->runCommands($commands, workingPath: $this->absolutePath, taskLabel: 'Initializing Git repository');
 
         return $this;
     }

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -90,7 +90,8 @@ class NewCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Optionally specify the name of the GitHub repository')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'Creates a super user with this email address')
-            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user');
+            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user')
+            ->addOption('disable-title', null, InputOption::VALUE_NONE, "Don't show title art");
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -327,6 +328,10 @@ class NewCommand extends Command
      */
     protected function showStatamicTitleArt()
     {
+        if ($this->input->hasOption('disable-title')) {
+            return $this;
+        }
+
         $this->output->write(PHP_EOL.'<fg=#D4FF4C>
   █▀ ▀█▀ ▄▀█ ▀█▀ ▄▀█ █▀▄▀█ █ █▀▀
   ▄█ ░█░ █▀█ ░█░ █▀█ █░▀░█ █ █▄▄</>'.PHP_EOL.PHP_EOL);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -91,7 +91,7 @@ class NewCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'Creates a super user with this email address')
             ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user')
-            ->addOption('disable-title', null, InputOption::VALUE_NONE, "Don't show title art");
+            ->addOption('no-ascii-art', null, InputOption::VALUE_NONE, "Don't show the ASCII art title");
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -328,7 +328,7 @@ class NewCommand extends Command
      */
     protected function showStatamicTitleArt()
     {
-        if ($this->input->hasOption('disable-title')) {
+        if ($this->input->getOption('no-ascii-art')) {
             return $this;
         }
 


### PR DESCRIPTION
This pull request integrates the [`task()` helper](https://laravel.com/docs/13.x/prompts#task) from `laravel/prompts` into the install process, similar to what the Laravel installer has started doing.

The `composer create-project` step and git init step currently dump their raw, scrolling command output straight to the terminal. This PR wraps them in a `task()` instead, which collapses the output into a spinner with a live-updating log, finishing as a single `✔ Installing Statamic` / `✔ Initializing Git repository` line on success.

This only kicks in when `task()` and `pcntl_fork` are available and output is decorated at normal verbosity — otherwise `RunsCommands` falls back to the existing raw scrolling output, so behaviour is unchanged for `--no-ansi`, `-v`, and non-interactive/non-decorated environments.