### PR TITLE
Recommend cpx for installing the CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,23 @@
     - [Installing Statamic](#installing-statamic)
     - [Checking Statamic versions](#checking-statamic-versions)
     - [Updating Statamic](#updating-statamic)
+- [Installing directly](#installing-directly)
 
 ## Installing the CLI tool
 
+We recommend running the CLI tool through [cpx](https://cpx.dev), rather than installing it directly. cpx runs Composer packages on-the-fly, so you'll always be using the latest version of the CLI tool without needing to update it yourself.
+
+First, install cpx:
+
 ```
-composer global require statamic/cli
+composer global require cpx/cpx
 ```
 
-Make sure to place Composer's system-wide vendor bin directory in your `$PATH` so the `statamic` executable can be located by your system. [Here's how](https://statamic.dev/troubleshooting/command-not-found-statamic).
+Then you can run the CLI tool with:
 
-Once installed, you should be able to run `statamic {command name}` from within any directory.
+```
+cpx statamic/cli {command name}
+```
 
 ### GitHub authentication
 
@@ -28,14 +35,6 @@ composer config --global --auth github-oauth.github.com [your_token_here]
 
 Read more on this in the [Composer Docs](https://getcomposer.org/doc/articles/authentication-for-private-packages.md).
 
-## Updating the CLI tool
-
-```
-composer global update statamic/cli
-```
-
-Run this command to update the CLI tool to the most recent published version. If there's been a major version release, you may need to run `require` instead of update.
-
 ## Using the CLI tool
 
 ### Installing Statamic
@@ -43,15 +42,15 @@ Run this command to update the CLI tool to the most recent published version. If
 You may create a new Statamic site with the `new` command:
 
 ```
-statamic new my-site
+cpx statamic/cli new my-site
 ```
 
-This will present you with a list of supported starter kits to select from.  Upon selection, the latest version will be downloaded and installed into the `my-site` directory.
+This will present you with a list of supported starter kits to select from. Upon selection, the latest version will be downloaded and installed into the `my-site` directory.
 
 You may also pass an explicit starter kit repo if you wish to skip the selection prompt:
 
 ```
-statamic new my-site statamic/starter-kit-cool-writings
+cpx statamic/cli new my-site statamic/starter-kit-cool-writings
 ```
 
 ### Checking Statamic versions
@@ -59,7 +58,7 @@ statamic new my-site statamic/starter-kit-cool-writings
 From within an existing Statamic project root directory, you may run the following command to quickly find out which version is being used.
 
 ```
-statamic version
+cpx statamic/cli version
 ```
 
 ### Updating Statamic
@@ -67,7 +66,27 @@ statamic version
 From within an existing Statamic project root directory, you may use the following command to update to the latest version.
 
 ```
-statamic update
+cpx statamic/cli update
 ```
 
 This is just syntactic sugar for the `composer update statamic/cms --with-dependencies` command.
+
+## Installing directly
+
+If you'd rather not use cpx, you can install the CLI tool directly instead:
+
+```
+composer global require statamic/cli
+```
+
+Make sure to place Composer's system-wide vendor bin directory in your `$PATH` so the `statamic` executable can be located by your system. [Here's how](https://statamic.dev/troubleshooting/command-not-found-statamic).
+
+Once installed, you should be able to run `statamic {command name}` from within any directory, in place of `cpx statamic/cli {command name}` above.
+
+To update the CLI tool itself to the most recent published version, run:
+
+```
+composer global update statamic/cli
+```
+
+If there's been a major version release, you may need to run `require` instead of `update`.

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -90,7 +90,8 @@ class NewCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Optionally specify the name of the GitHub repository')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'Creates a super user with this email address')
-            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user');
+            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user')
+            ->addOption('disable-title', null, InputOption::VALUE_NONE, "Don't show title art");
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -327,6 +328,10 @@ class NewCommand extends Command
      */
     protected function showStatamicTitleArt()
     {
+        if ($this->input->hasOption('disable-title')) {
+            return $this;
+        }
+
         $this->output->write(PHP_EOL.'<fg=#D4FF4C>
   █▀ ▀█▀ ▄▀█ ▀█▀ ▄▀█ █▀▄▀█ █ █▀▀
   ▄█ ░█░ █▀█ ░█░ █▀█ █░▀░█ █ █▄▄</>'.PHP_EOL.PHP_EOL);

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -91,7 +91,7 @@ class NewCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'Creates a super user with this email address')
             ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user')
-            ->addOption('disable-title', null, InputOption::VALUE_NONE, "Don't show title art");
+            ->addOption('no-ascii-art', null, InputOption::VALUE_NONE, "Don't show the ASCII art title");
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -328,7 +328,7 @@ class NewCommand extends Command
      */
     protected function showStatamicTitleArt()
     {
-        if ($this->input->hasOption('disable-title')) {
+        if ($this->input->getOption('no-ascii-art')) {
             return $this;
         }
 

--- a/src/NewCommand.php
+++ b/src/NewCommand.php
@@ -90,8 +90,7 @@ class NewCommand extends Command
             ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'Optionally specify the name of the GitHub repository')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force install even if the directory already exists')
             ->addOption('email', null, InputOption::VALUE_OPTIONAL, 'Creates a super user with this email address')
-            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user')
-            ->addOption('no-ascii-art', null, InputOption::VALUE_NONE, "Don't show the ASCII art title");
+            ->addOption('password', null, InputOption::VALUE_OPTIONAL, 'Password for the super user');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -328,10 +327,6 @@ class NewCommand extends Command
      */
     protected function showStatamicTitleArt()
     {
-        if ($this->input->getOption('no-ascii-art')) {
-            return $this;
-        }
-
         $this->output->write(PHP_EOL.'<fg=#D4FF4C>
   █▀ ▀█▀ ▄▀█ ▀█▀ ▄▀█ █▀▄▀█ █ █▀▀
   ▄█ ░█░ █▀█ ░█░ █▀█ █░▀░█ █ █▄▄</>'.PHP_EOL.PHP_EOL);


### PR DESCRIPTION
This pull request updates the README to recommend installing the CLI tool via [cpx](https://cpx.dev), rather than installing it directly.

cpx runs Composer packages on-the-fly, so folks always get the latest version of the CLI tool without needing to run `composer global update` themselves.

This PR also moves the direct `composer global require statamic/cli` install into its own "Installing directly" section at the bottom, for anyone who'd rather not use cpx.